### PR TITLE
feat(bridge): Add hash-based recipient resolution for cross-chain dep…

### DIFF
--- a/daml/bridge-core/src/Bridge/Contracts.daml
+++ b/daml/bridge-core/src/Bridge/Contracts.daml
@@ -3,7 +3,53 @@ module Bridge.Contracts where
 import Common.Types
 import CIP56.Token
 
--- Mint proposal for bridging tokens from EVM to Canton
+-- =============================================================================
+-- HASH-BASED MINT PROPOSAL (Resolves recipient from PartyHashRegistry)
+-- =============================================================================
+--
+-- This template enables the middleware to pass the raw bytes32 cantonRecipient
+-- from Ethereum's DepositToCanton event. Canton resolves it to a Party.
+--
+-- Flow:
+-- 1. Ethereum: User calls depositToCanton(token, amount, bytes32 recipientHash)
+-- 2. Middleware: Sees event, creates MintProposalByHash with the raw hash
+-- 3. Canton: Resolves hash → Party via PartyHashRegistry lookup
+-- 4. Recipient: Accepts the proposal (same as standard flow)
+
+-- | Mint proposal created by hash lookup
+-- 
+-- The operator creates this after looking up the PartyHashRegistry.
+-- This is functionally equivalent to MintProposal but documents that
+-- the recipient was resolved from a hash.
+template MintProposalByHash
+  with
+    operator        : Party
+    issuer          : Party
+    recipient       : Party          -- Resolved from PartyHashRegistry
+    recipientHash   : Text           -- Original hash from Ethereum (for audit)
+    tokenManagerCid : ContractId CIP56Manager
+    amount          : Decimal
+    reference       : Text           -- EVM tx hash
+    source          : ChainRef
+  where
+    signatory operator
+    observer recipient
+
+    key (operator, reference) : (Party, Text)
+    maintainer key._1
+
+    -- | Recipient accepts, creating authorization for minting
+    choice AcceptByHash : ContractId MintAuthorization
+      controller recipient
+      do
+        create MintAuthorization with 
+          operator, issuer, recipient, tokenManagerCid, amount, reference, source
+
+-- =============================================================================
+-- STANDARD MINT FLOW (Direct recipient specification)
+-- =============================================================================
+
+-- | Mint proposal for bridging tokens from EVM to Canton
 template MintProposal
   with
     operator        : Party

--- a/daml/bridge-wayfinder/TESTING.md
+++ b/daml/bridge-wayfinder/TESTING.md
@@ -48,7 +48,7 @@ daml/
 │       └── Contracts.daml    # MintProposal, RedeemRequest, BurnEvent
 └── bridge-wayfinder/         # Wayfinder-specific bridge
     └── src/Wayfinder/
-        ├── Bridge.daml       # WayfinderBridgeConfig, primeMetadata
+        ├── Bridge.daml       # WayfinderBridgeConfig, promptMetadata
         └── Test.daml         # End-to-end test script
 ```
 
@@ -315,7 +315,7 @@ daml script \
 | Step | Assertion | Purpose |
 |------|-----------|---------|
 | Deposit | `aliceHolding.amount == 100.0` | Verify correct mint amount |
-| Deposit | `aliceHolding.meta.symbol == "PRIME"` | Verify token metadata |
+| Deposit | `aliceHolding.meta.symbol == "PROMPT"` | Verify token metadata |
 | Transfer | `bobHolding.amount == 40.0` | Verify transfer amount |
 | Transfer | `change.amount == 60.0` | Verify change returned |
 | Withdrawal | `burnEvent.amount == 40.0` | Verify burn amount |

--- a/daml/bridge-wayfinder/src/Wayfinder/Bridge.daml
+++ b/daml/bridge-wayfinder/src/Wayfinder/Bridge.daml
@@ -7,7 +7,7 @@ import Bridge.Contracts
 -- Wayfinder PROMPT Token Metadata
 promptMetadata : ExtendedMetadata
 promptMetadata = ExtendedMetadata with
-  name = "Wayfinder"
+  name = "Wayfinder PROMPT"
   symbol = "PROMPT"
   decimals = 18
   isin = None
@@ -31,7 +31,65 @@ template WayfinderBridgeConfig
       do
         pure promptMetadata
 
-    -- Helper to initiate a mint proposal (Standard Bridge Flow)
+    -- =========================================================================
+    -- HASH-BASED MINT (Middleware passes raw bytes32, Canton resolves)
+    -- =========================================================================
+    
+    -- | Create mint proposal by looking up recipient from PartyHashRegistry
+    -- 
+    -- This is the PRIMARY method for deposits. The middleware:
+    -- 1. Monitors DepositToCanton events on Ethereum
+    -- 2. Extracts the bytes32 cantonRecipient as hex string
+    -- 3. Calls this choice with the raw hash (NO lookup in middleware)
+    -- 4. Canton resolves hash → Party via PartyHashRegistry
+    --
+    -- If the hash is not registered, this will fail with "recipient not found"
+    nonconsuming choice CreateMintProposalByHash : ContractId MintProposalByHash
+      with
+        recipientHash : Text    -- bytes32 from Ethereum as hex "0xABC..."
+        amount        : Decimal
+        txHash        : Text    -- EVM transaction hash
+      controller operator
+      do
+        -- Look up the registry to resolve hash → Party
+        (_, registry) <- fetchByKey @PartyHashRegistry (operator, recipientHash)
+        
+        create MintProposalByHash with
+          operator = operator
+          issuer = operator
+          recipient = registry.owner  -- Resolved from registry!
+          recipientHash = recipientHash
+          tokenManagerCid = tokenManagerCid
+          amount = amount
+          reference = txHash
+          source = ChainRef with chainName = "Ethereum", eventId = txHash
+
+    -- =========================================================================
+    -- REGISTRATION HELPERS
+    -- =========================================================================
+    
+    -- | Approve a party hash registration request
+    -- 
+    -- Users submit PartyHashRegistrationRequest, operator approves here.
+    -- This creates the PartyHashRegistry entry that enables hash-based mints.
+    nonconsuming choice ApprovePartyRegistration : ContractId PartyHashRegistry
+      with
+        requestCid : ContractId PartyHashRegistrationRequest
+      controller operator
+      do
+        exercise requestCid ApproveRegistration
+
+    -- =========================================================================
+    -- STANDARD MINT (Direct recipient - for testing/admin use)
+    -- =========================================================================
+    
+    -- | Helper to initiate a mint proposal (Standard Bridge Flow)
+    -- 
+    -- Use CreateMintProposalByHash for production deposits.
+    -- This is useful for:
+    -- - Testing without registry setup
+    -- - Admin/manual mints
+    -- - Backwards compatibility
     nonconsuming choice CreateMintProposal : ContractId MintProposal
       with
         recipient : Party
@@ -41,7 +99,7 @@ template WayfinderBridgeConfig
       do
         create MintProposal with
           operator = operator
-          issuer = operator -- In Phase 0/1 model, operator is often issuer. Can be separated.
+          issuer = operator
           recipient = recipient
           tokenManagerCid = tokenManagerCid
           amount = amount

--- a/daml/bridge-wayfinder/src/Wayfinder/Script.daml
+++ b/daml/bridge-wayfinder/src/Wayfinder/Script.daml
@@ -6,18 +6,11 @@ import CIP56.Token
 import Bridge.Contracts
 import Wayfinder.Bridge
 
-ensureParty : Text -> PartyIdHint -> Script Party
-ensureParty displayName hint = do
-  known <- listKnownParties
-  case [ p.party | p <- known, p.displayName == Some displayName ] of
-    p :: _ -> pure p
-    []     -> allocatePartyWithHint displayName hint
-
 testFullCycle : Script ()
 testFullCycle = script do
   -- 1. Setup Parties
-  operator <- ensureParty "WayfinderOperator" (PartyIdHint "operator")
-  alice <- ensureParty "Alice" (PartyIdHint "alice")
+  operator <- allocatePartyWithHint "WayfinderOperator" (PartyIdHint "operator")
+  alice <- allocatePartyWithHint "Alice" (PartyIdHint "alice")
   
   -- 2. Deploy Token Manager for PROMPT
   tokenManagerCid <- submit operator do

--- a/daml/bridge-wayfinder/src/Wayfinder/Test.daml
+++ b/daml/bridge-wayfinder/src/Wayfinder/Test.daml
@@ -163,3 +163,163 @@ testWayfinderBridge = script do
   debug ">>> Test Cycle Complete Successfully!"
   
   pure ()
+
+-- =============================================================================
+-- HASH-BASED REGISTRATION AND MINT FLOW TEST
+-- =============================================================================
+
+-- | Test the hash-based recipient resolution flow
+--
+-- This demonstrates the production flow where:
+-- 1. User registers their Canton party hash on Canton (one-time)
+-- 2. User deposits on Ethereum with their hash as cantonRecipient
+-- 3. Middleware passes raw hash through (no lookup)
+-- 4. Canton resolves hash → Party and creates mint proposal
+testHashBasedMintFlow : Script ()
+testHashBasedMintFlow = script do
+  -- ===========================================================================
+  -- 1. INITIALIZATION
+  -- ===========================================================================
+  (operator, alice, bob) <- setupParties
+  
+  debug ">>> Hash-Based Flow Test"
+  debug ">>> 1. Initialization..."
+
+  tokenManagerCid <- submit operator do
+    createCmd CIP56Manager with
+      issuer = operator
+      meta = promptMetadata
+
+  configCid <- submit operator do
+    createCmd WayfinderBridgeConfig with
+      operator = operator
+      tokenManagerCid = tokenManagerCid
+
+  debug "    [OK] Bridge deployed."
+
+  -- ===========================================================================
+  -- 2. USER REGISTRATION (One-time on Canton)
+  -- ===========================================================================
+  debug ">>> 2. Alice registers her party hash..."
+
+  -- Alice computes her hash off-chain: keccak256("Alice::1220...")
+  -- For this test, we use a simulated hash
+  let alicePartyHash = "0xabcd1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab"
+  let aliceEvmAddress = EvmAddress "0xAliceEthWallet..."
+
+  -- Alice submits a registration request
+  registrationRequestCid <- submit alice do
+    createCmd PartyHashRegistrationRequest with
+      owner = alice
+      operator = operator
+      partyHash = alicePartyHash
+      evmAddress = Some aliceEvmAddress
+
+  debug "    [OK] Alice submitted registration request."
+
+  -- Operator approves the registration
+  aliceRegistryCid <- submit operator do
+    exerciseCmd configCid ApprovePartyRegistration with
+      requestCid = registrationRequestCid
+
+  -- Verify registration
+  Some aliceRegistry <- queryContractId alice aliceRegistryCid
+  assertMsg "Registry owner should be Alice" (aliceRegistry.owner == alice)
+  assertMsg "Registry hash should match" (aliceRegistry.partyHash == alicePartyHash)
+
+  debug "    [OK] Registration approved. Alice can now receive deposits."
+
+  -- ===========================================================================
+  -- 3. HASH-BASED DEPOSIT (Middleware passes raw bytes32)
+  -- ===========================================================================
+  debug ">>> 3. Deposit with hash-based recipient resolution..."
+
+  -- Simulate: Middleware sees DepositToCanton event on Ethereum
+  -- Event contains: token, sender (0xAliceEthWallet), cantonRecipient (bytes32), amount, nonce
+  -- Middleware just passes the raw bytes32 to Canton
+  let ethTxHash = "0xEthDepositTx123..."
+  let depositAmount = 250.0
+
+  -- Middleware calls CreateMintProposalByHash with raw hash
+  -- Canton resolves: hash → PartyHashRegistry → Alice
+  proposalCid <- submit operator do
+    exerciseCmd configCid CreateMintProposalByHash with
+      recipientHash = alicePartyHash  -- Raw bytes32 from Ethereum event
+      amount = depositAmount
+      txHash = ethTxHash
+
+  debug "    [OK] Mint proposal created via hash lookup."
+
+  -- Verify the proposal resolved to Alice
+  Some proposal <- queryContractId alice proposalCid
+  assertMsg "Recipient should be Alice" (proposal.recipient == alice)
+  assertMsg "Hash should be preserved for audit" (proposal.recipientHash == alicePartyHash)
+
+  -- ===========================================================================
+  -- 4. ALICE ACCEPTS (Same as standard flow from here)
+  -- ===========================================================================
+  debug ">>> 4. Alice accepts the proposal..."
+
+  authCid <- submit alice do
+    exerciseCmd proposalCid AcceptByHash
+
+  aliceHoldingCid <- submit operator do
+    exerciseCmd authCid MintOnCanton
+
+  -- Verify Alice's balance
+  Some aliceHolding <- queryContractId alice aliceHoldingCid
+  assertMsg "Alice should have 250.0 PROMPT" (aliceHolding.amount == 250.0)
+
+  debug "    [OK] Alice received 250.0 PROMPT via hash-based flow."
+
+  -- ===========================================================================
+  -- 5. SECURITY TEST: Unregistered hash should fail
+  -- ===========================================================================
+  debug ">>> 5. Security: Unregistered hash should fail..."
+
+  let unregisteredHash = "0xDEADBEEF0000000000000000000000000000000000000000000000000000DEAD"
+
+  -- This should fail because the hash is not in the registry
+  submitMustFail operator do
+    exerciseCmd configCid CreateMintProposalByHash with
+      recipientHash = unregisteredHash
+      amount = 1000.0
+      txHash = "0xAttackerTx..."
+
+  debug "    [OK] Unregistered hash rejected."
+
+  -- ===========================================================================
+  -- 6. BOB REGISTERS AND RECEIVES
+  -- ===========================================================================
+  debug ">>> 6. Bob registers and receives deposit..."
+
+  let bobPartyHash = "0xBBBB1234567890abcdef1234567890abcdef1234567890abcdef1234567890BB"
+
+  -- Bob registers directly (operator can allow direct registration)
+  bobRegistryCid <- submitMulti [bob, operator] [] do
+    createCmd PartyHashRegistry with
+      owner = bob
+      operator = operator
+      partyHash = bobPartyHash
+      evmAddress = Some (EvmAddress "0xBobEthWallet...")
+
+  -- Bob receives deposit via hash
+  bobProposalCid <- submit operator do
+    exerciseCmd configCid CreateMintProposalByHash with
+      recipientHash = bobPartyHash
+      amount = 100.0
+      txHash = "0xBobDepositTx..."
+
+  bobAuthCid <- submit bob do
+    exerciseCmd bobProposalCid AcceptByHash
+
+  bobHoldingCid <- submit operator do
+    exerciseCmd bobAuthCid MintOnCanton
+
+  Some bobHolding <- queryContractId bob bobHoldingCid
+  assertMsg "Bob should have 100.0 PROMPT" (bobHolding.amount == 100.0)
+
+  debug "    [OK] Bob received 100.0 PROMPT."
+
+  debug ">>> Hash-Based Flow Test Complete!"
+  pure ()

--- a/daml/common/src/Common/Types.daml
+++ b/daml/common/src/Common/Types.daml
@@ -48,3 +48,93 @@ toBasicMetadata em = TokenMeta with
   name     = em.name
   symbol   = em.symbol
   decimals = em.decimals
+
+-- =============================================================================
+-- PARTY HASH REGISTRY: Maps bytes32 hash → Canton Party
+-- =============================================================================
+-- 
+-- This template enables Canton-side resolution of Ethereum recipient hashes.
+-- The middleware passes the raw bytes32 from DepositToCanton events, and
+-- Canton resolves it to a Party using this registry.
+--
+-- Flow:
+-- 1. User registers ONCE on Canton: keccak256(partyId) → Party
+-- 2. User deposits on Ethereum with their hash as cantonRecipient
+-- 3. Middleware passes hash through (no lookup needed)
+-- 4. Canton resolves hash → Party and creates MintProposal
+
+-- | Registry entry linking a keccak256 hash to a Canton Party
+--
+-- Users create this to register their Canton party with the bridge.
+-- The partyHash should be keccak256(fullCantonPartyId) as hex string.
+--
+-- Example: If Alice's full party ID is "Alice::1220abcd1234..."
+--          partyHash = "0x" + keccak256("Alice::1220abcd1234...").hex()
+--
+-- Note: Both owner and operator are signatories to enable lookup by (operator, hash)
+-- This requires the registration request → approval pattern for creation.
+template PartyHashRegistry
+  with
+    owner     : Party   -- The Canton party this hash resolves to
+    operator  : Party   -- Bridge operator (signatory for lookup key)
+    partyHash : Text    -- keccak256(partyId) as hex string "0xABC..."
+    evmAddress : Optional EvmAddress  -- Optional: linked EVM address for withdrawals
+  where
+    signatory owner, operator  -- Both signatories for key maintainer requirement
+    
+    -- Key by (operator, partyHash) for O(1) lookup by hash
+    -- This enables: fetchByKey @PartyHashRegistry (operator, hash)
+    key (operator, partyHash) : (Party, Text)
+    maintainer key._1
+    
+    -- | Update the linked EVM address for withdrawals
+    choice UpdateEvmAddress : ContractId PartyHashRegistry
+      with
+        newEvmAddress : EvmAddress
+      controller owner
+      do
+        create this with evmAddress = Some newEvmAddress
+    
+    -- | Unregister (archive) this entry
+    choice Unregister : ()
+      controller owner
+      do
+        pure ()
+
+-- | Request to register a party hash (if operator approval is required)
+-- 
+-- Use this if the bridge requires operator approval for registrations.
+-- Otherwise, users can create PartyHashRegistry directly if operator
+-- is set up to auto-accept via a config contract.
+template PartyHashRegistrationRequest
+  with
+    owner     : Party
+    operator  : Party
+    partyHash : Text
+    evmAddress : Optional EvmAddress
+  where
+    signatory owner
+    observer operator
+    
+    key (operator, owner, partyHash) : (Party, Party, Text)
+    maintainer key._2
+    
+    -- | Operator approves the registration
+    choice ApproveRegistration : ContractId PartyHashRegistry
+      controller operator
+      do
+        create PartyHashRegistry with
+          owner = owner
+          operator = operator
+          partyHash = partyHash
+          evmAddress = evmAddress
+    
+    -- | Operator rejects the registration
+    choice RejectRegistration : ()
+      controller operator
+      do pure ()
+    
+    -- | Owner cancels the request
+    choice CancelRegistration : ()
+      controller owner
+      do pure ()


### PR DESCRIPTION


- Add PartyHashRegistry template for Canton-side hash→Party resolution
- Add PartyHashRegistrationRequest for user onboarding flow
- Add MintProposalByHash template preserving original hash for audit
- Add CreateMintProposalByHash choice to WayfinderBridgeConfig
- Middleware passes raw bytes32 cantonRecipient, Canton resolves

This enables the existing Ethereum CantonBridge.sol bytes32 cantonRecipient field to be used without additional middleware complexity. Users register their party hash once on Canton, then deposits are automatically routed.

Also fixes token naming: PRIME → PROMPT (matches Etherscan contract)

