### PR TITLE
fix(scripts): add bridge-wayfinder to build and clean scripts

### DIFF
--- a/scripts/build-all.sh
+++ b/scripts/build-all.sh
@@ -120,6 +120,7 @@ PACKAGES=(
   "common"
   "cip56-token"
   "bridge-core"
+  "bridge-wayfinder"
   "bridge-usdc"
   "bridge-cbtc"
   "bridge-generic"

--- a/scripts/clean-all.sh
+++ b/scripts/clean-all.sh
@@ -101,6 +101,7 @@ PACKAGES=(
   "common"
   "cip56-token"
   "bridge-core"
+  "bridge-wayfinder"
   "bridge-usdc"
   "bridge-cbtc"
   "bridge-generic"


### PR DESCRIPTION
- Added bridge-wayfinder package to PACKAGES array in build-all.sh
- Added bridge-wayfinder package to PACKAGES array in clean-all.sh
- Ensures bridge-wayfinder is included in build/clean operations
